### PR TITLE
[#12] FIX FIxes login check

### DIFF
--- a/package/opClient/main.go
+++ b/package/opClient/main.go
@@ -73,10 +73,11 @@ func (client OpClient) isLoggedIn() (bool, error) {
 	if err != nil {
 		client.sys.Crash("Something wen't wrong when recovering the account", err)
 	}	
-	_, err = client.commandRunner.Run(client.path, "whoami", "--session", token, "--account", account)
+	_, err = client.commandRunner.Run(client.path, "account", "get", "--session", token, "--account", account)
 
 	// Whoami returns no error -> we are logged in
 	if err == nil {
+		client.sys.NotifyUser("IOP", "Already logged in!")
 		return true, nil
 	}
 

--- a/package/opClient/main_test.go
+++ b/package/opClient/main_test.go
@@ -59,10 +59,10 @@ func TestEnsureLoggedInCallsLoginIfNotLoggedIn(t *testing.T) {
 
 func TestEnsureLoggedInSavesTokenUsingTokenStorage(t *testing.T) {
 	templateData := struct{
-		WhoAmIExitCode string
+		AccountGetExitCode string
 		Body string
 	}{"1", "echo -n 123"}
-	scriptPath := testUtils.RenderTemplateTestFile(t, "mocked_whoami_script.sh", templateData)
+	scriptPath := testUtils.RenderTemplateTestFile(t, "mocked_op.sh", templateData)
 	tokenStorage := tokenStorage.NewInMemoryTokenStorage("")
 	opClient := NewTestOpClient(
 		WithTokenStorage(&tokenStorage),

--- a/package/opClient/test_data/mocked_op.sh
+++ b/package/opClient/test_data/mocked_op.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 # A helper script to control exit code of `whoami` and other commands.
-if [ "$1" == "whoami" ]
+if [ "$1" == "account" ] && [ "$2" == "get" ]
 then
-    exit {{.WhoAmIExitCode}}
+    exit {{.AccountGetExitCode}}
 fi
 {{.Body}}


### PR DESCRIPTION
- Uses `account get` rather than `whoami` since the second is ignoring
the session parameter

Closes #12
